### PR TITLE
Update plugin to support more declarations and write output to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,31 @@ The following instructions assume an Ubuntu 22.04 LTS operating system:
   sudo apt install llvm-17 clang-17 libclang-17-dev
   ```
 
+For installation on the FreeBSD operating system, follow these instructions:
+
+- Ninja
+  
+  ```shell
+    sudo pkg install ninja
+  ```
+
+- CMake 3.29.1
+  
+  ```shell
+    sudo pkg install cmake
+  ```
+
+- LLVM 17
+
+  First, check that llvm version 17 is available by running: 
+  ```shell
+    sudo pkg search llvm
+  ```
+
+  If llvm-17 is available:
+  ```shell
+    sudo pkg install llvm17
+  ```
 ### Building the Clang plugin
 
 1. Configure the plugin:
@@ -61,6 +86,14 @@ MacOS:
 ```shell
 /opt/homebrew/opt/llvm@17/bin/clang \
     -fplugin=./build/lib/Debug/libopenbsd_list_macro_printer.dylib \
+    -fsyntax-only \
+    test/slist.c
+```
+
+FreeBSD:
+```shell
+/usr/local/llvm17/bin/clang \
+    -fplugin=./build/lib/Release/libopenbsd_list_macro_printer.dylib \
     -fsyntax-only \
     test/slist.c
 ```

--- a/build-freebsd.sh
+++ b/build-freebsd.sh
@@ -1,0 +1,7 @@
+cmake -S . -B build -G "Ninja Multi-Config" \
+    -D CMAKE_C_COMPILER=/usr/local/llvm17/bin/clang \
+    -D CMAKE_CXX_COMPILER=/usr/local/llvm17/bin/clang++ \
+    -D Clang_DIR=/usr/local/llvm17/lib/cmake/clang \
+    -D LLVM_DIR=/usr/local/llvm17/lib/cmake/llvm
+
+cmake --build build/ --config Release

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -205,6 +205,43 @@ void PrintListIteratorForSLIST_HEADDecl(clang::ASTContext &Ctx,
   llvm::outs() << "    }\n}\n";
 }
 
+/* Prints the list iterator function for a declaration declared using the
+ * LIST_HEAD() macro. */
+void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
+                                        OpenBSDQueueMacroDecl LIST_HEADDecl) {
+  auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
+  auto RecordDecl = LIST_HEADDecl.RecordDecl;
+  const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
+  auto lh_firstFieldDecl = *RecordDecl->field_begin();
+  auto lh_firstFieldRecordDecl =
+      lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
+
+  /* Find the field in the entry declaration that was expanded from
+   * LIST_ENTRY(). */
+  using namespace clang::ast_matchers;
+  MatchFinder Finder;
+  FieldDeclarationMatcherCallback FDMC;
+  DeclarationMatcher LIST_ENTRYMatcher = recordDecl(has(
+      fieldDecl(
+          hasType(recordDecl(isExpandedFromMacro(std::string("LIST_ENTRY")))))
+          .bind("root")));
+  Finder.addMatcher(LIST_ENTRYMatcher, &FDMC);
+  Finder.match(*lh_firstFieldRecordDecl, Ctx);
+  /* LIST_ENTRY() should be called exactly once in the declaration of list's
+   * entry type. */
+  assert(1 == FDMC.Matches.size());
+  lh_firstFieldRecordDeclLIST_ENTRYField = FDMC.Matches.front();
+
+  llvm::outs() << std::format(
+      "{{\n    struct {} * __openbsd_list_iterator;\n    "
+      "LIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
+      lh_firstFieldRecordDecl->getNameAsString(), DeclName,
+      lh_firstFieldRecordDeclLIST_ENTRYField->getNameAsString());
+  PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
+                                   lh_firstFieldRecordDecl);
+  llvm::outs() << "    }\n}\n";
+}
+
 /* We only define this constructor because Clang requires it. */
 ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 
@@ -227,6 +264,8 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
         PrintListIteratorForSLIST_HEADDecl(Ctx, Match);
+      } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match);
       }
       first = false;
     }

--- a/lib/ASTConsumer.cc
+++ b/lib/ASTConsumer.cc
@@ -11,6 +11,8 @@
 #include <format>
 #include <string>
 #include <vector>
+#include <unordered_set>
+#include <fstream>
 
 namespace openbsd_list_macro_printer {
 
@@ -139,10 +141,8 @@ FindOpenBSDQueueMacroDecls(clang::ASTContext &Ctx,
  *     printf("%s", np->b);
  * ```
  */
-void PrintPrintersForRecordDeclFields(unsigned indent,
-                                      std::string RecordDeclVarName,
-                                      const clang::RecordDecl *RecordDecl) {
-
+void PrintPrintersForRecordDeclFields(unsigned indent, std::string RecordDeclVarName,
+                                      const clang::RecordDecl *RecordDecl, std::ofstream &file) {
   for (const auto FieldDecl : RecordDecl->fields()) {
     std::string FormatSpecifier;
     std::string PrintfArgument =
@@ -151,64 +151,22 @@ void PrintPrintersForRecordDeclFields(unsigned indent,
     if (Type->isPointerType() && Type->getPointeeType()->isCharType()) {
       FormatSpecifier = "%s";
     }
-    /* If we didn't already determine a format specifier for this type, try to
-     * do so now. */
     if (Type->isUnsignedIntegerType()) {
       FormatSpecifier = "%u";
     } else if (Type->isSignedIntegerType()) {
       FormatSpecifier = "%d";
     }
-    /* If we inferred a type for this field, print out its printer. */
+
     if (!FormatSpecifier.empty()) {
-      llvm::outs() << std::format("{}printf(\"{}\", {});\n",
-                                  std::string(indent, ' '), FormatSpecifier,
-                                  PrintfArgument);
+      file << std::string(indent, ' ') << std::format("printf(\"{}\", {});\n",
+                                  FormatSpecifier, PrintfArgument);
     }
   }
 }
 
-/* Prints the list iterator function for a declaration declared using the
- * SLIST_HEAD() macro. */
-void PrintListIteratorForSLIST_HEADDecl(clang::ASTContext &Ctx,
-                                        OpenBSDQueueMacroDecl SLIST_HEADDecl) {
-  auto DeclName = SLIST_HEADDecl.VarDecl->getNameAsString();
-  auto RecordDecl = SLIST_HEADDecl.RecordDecl;
-  const clang::FieldDecl *slh_firstFieldRecordDeclSLIST_ENTRYField;
-  auto slh_firstFieldDecl = *RecordDecl->field_begin();
-  auto slh_firstFieldRecordDecl =
-      slh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
-
-  /* Find the field in the entry declaration that was expanded from
-   * SLIST_ENTRY(). */
-  using namespace clang::ast_matchers;
-  MatchFinder Finder;
-  FieldDeclarationMatcherCallback FDMC;
-  DeclarationMatcher SLIST_ENTRYMatcher = recordDecl(has(
-      fieldDecl(
-          hasType(recordDecl(isExpandedFromMacro(std::string("SLIST_ENTRY")))))
-          .bind("root")));
-  Finder.addMatcher(SLIST_ENTRYMatcher, &FDMC);
-  Finder.match(*slh_firstFieldRecordDecl, Ctx);
-  /* SLIST_ENTRY() should be called exactly once in the declaration of list's
-   * entry type. */
-  assert(1 == FDMC.Matches.size());
-  slh_firstFieldRecordDeclSLIST_ENTRYField = FDMC.Matches.front();
-
-  // NOTE(Brent): We assume that this is a decl of a struct.
-  llvm::outs() << std::format(
-      "{{\n    struct {} * __openbsd_list_iterator;\n    "
-      "SLIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
-      slh_firstFieldRecordDecl->getNameAsString(), DeclName,
-      slh_firstFieldRecordDeclSLIST_ENTRYField->getNameAsString());
-  PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
-                                   slh_firstFieldRecordDecl);
-  llvm::outs() << "    }\n}\n";
-}
-
-/* Prints the list iterator function for a declaration declared using the
- * LIST_HEAD() macro. */
 void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
-                                        OpenBSDQueueMacroDecl LIST_HEADDecl) {
+                                       OpenBSDQueueMacroDecl LIST_HEADDecl,
+                                       const std::string& entryName) {
   auto DeclName = LIST_HEADDecl.VarDecl->getNameAsString();
   auto RecordDecl = LIST_HEADDecl.RecordDecl;
   const clang::FieldDecl *lh_firstFieldRecordDeclLIST_ENTRYField;
@@ -216,30 +174,40 @@ void PrintListIteratorForLIST_HEADDecl(clang::ASTContext &Ctx,
   auto lh_firstFieldRecordDecl =
       lh_firstFieldDecl->getType()->getPointeeType()->getAsRecordDecl();
 
-  /* Find the field in the entry declaration that was expanded from
-   * LIST_ENTRY(). */
+  // Open a file based on the record name
+  std::ofstream file(std::string{"/usr/src/table_src/"} + DeclName + "_tbl.c");
+
+  if (!file.is_open()) {
+    llvm::errs() << "Error opening file: " << DeclName + "_tbl.c" << "\n";
+    return;
+  }
+
   using namespace clang::ast_matchers;
   MatchFinder Finder;
   FieldDeclarationMatcherCallback FDMC;
   DeclarationMatcher LIST_ENTRYMatcher = recordDecl(has(
       fieldDecl(
-          hasType(recordDecl(isExpandedFromMacro(std::string("LIST_ENTRY")))))
+          hasType(recordDecl(isExpandedFromMacro(std::string(entryName)))))
           .bind("root")));
   Finder.addMatcher(LIST_ENTRYMatcher, &FDMC);
   Finder.match(*lh_firstFieldRecordDecl, Ctx);
-  /* LIST_ENTRY() should be called exactly once in the declaration of list's
-   * entry type. */
   assert(1 == FDMC.Matches.size());
   lh_firstFieldRecordDeclLIST_ENTRYField = FDMC.Matches.front();
 
-  llvm::outs() << std::format(
+  llvm::outs() << "Processing file " << DeclName << '\n';
+
+  file << std::format(
       "{{\n    struct {} * __openbsd_list_iterator;\n    "
       "LIST_FOREACH(__openbsd_list_iterator, &{}, {}) {{\n",
       lh_firstFieldRecordDecl->getNameAsString(), DeclName,
       lh_firstFieldRecordDeclLIST_ENTRYField->getNameAsString());
+
   PrintPrintersForRecordDeclFields(8u, "__openbsd_list_iterator",
-                                   lh_firstFieldRecordDecl);
-  llvm::outs() << "    }\n}\n";
+                                   lh_firstFieldRecordDecl, file);
+
+  file << "    }\n}\n";
+
+  file.close();
 }
 
 /* We only define this constructor because Clang requires it. */
@@ -248,11 +216,17 @@ ASTConsumer::ASTConsumer(clang::CompilerInstance &CI) { (void)CI; }
 /* This is the method we have to override to tell Clang what do when we run our
 plugin. */
 void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
+  std::unordered_set<const clang::RecordDecl*> ProcessedRecords;
   auto first = true;
   /* Run the printer on every kind of OpenBSD list macro. */
   for (const auto &OpenBSDQueueMacroDeclName : OpenBSDQueueMacroDeclNames) {
     auto Matches = FindOpenBSDQueueMacroDecls(Ctx, OpenBSDQueueMacroDeclName);
     for (auto Match : Matches) {
+      if(ProcessedRecords.find(Match.RecordDecl) != ProcessedRecords.end()) {
+        llvm::outs() << "skipped declaration" << '\n'; 
+        continue;
+      }
+      ProcessedRecords.insert(Match.RecordDecl);
       /* Print a banner to separate different lists.
        *
        * TODO(Brent): Change the output format to something easily
@@ -263,9 +237,9 @@ void ASTConsumer::HandleTranslationUnit(clang::ASTContext &Ctx) {
       }
       /* TODO(Brent): Add printers for the other declaration macros. */
       if ("SLIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForSLIST_HEADDecl(Ctx, Match);
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "SLIST_ENTRY");
       } else if("LIST_HEAD" == Match.OpenBSDListDeclarationMacroName) {
-        PrintListIteratorForLIST_HEADDecl(Ctx, Match);
+        PrintListIteratorForLIST_HEADDecl(Ctx, Match, "LIST_ENTRY");
       }
       first = false;
     }


### PR DESCRIPTION
The plugin has been modified to support different list declarations, avoid processing repeat declarations, and also write to an appropriately named file. Currently, this "writing to file" mechanism is supported by writing to a hard coded path (/usr/src/table-src), which will have to be manually created before this plugin is run.